### PR TITLE
Update to Wasmer 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.0-dev
 
+- Update to Wasmer 2.0.0
 - All WASM modules and isntances use a singleton store, to enable sharing of
   memory and functions.
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer"
-version = "1.0.2"
+version = "2.0.0"
 
 [lib]
 name = "wasmer"
@@ -8,6 +8,6 @@ crate-type = ["staticlib"]
 path = "wasmer.rs"
 
 [dependencies.wasmer-c-api]
-version = "1.0.2"
+version = "2.0.0"
 default-features = false
 features = ["jit", "cranelift", "wasi"]

--- a/bin/finalizers.cc
+++ b/bin/finalizers.cc
@@ -24,3 +24,4 @@ FINALIZER(trap);
 FINALIZER(memorytype);
 FINALIZER(memory);
 FINALIZER(func);
+FINALIZER(global);

--- a/bin/module.g.def
+++ b/bin/module.g.def
@@ -19,7 +19,6 @@ EXPORTS
    wasi_env_new
    wasi_env_read_stderr
    wasi_env_read_stdout
-   wasi_env_set_memory
    wasi_get_imports
    wasm_byte_vec_delete
    wasm_byte_vec_new

--- a/bin/module.g.def
+++ b/bin/module.g.def
@@ -6,6 +6,7 @@ EXPORTS
    Dart_InitializeApiDL
    set_finalizer_for_engine
    set_finalizer_for_func
+   set_finalizer_for_global
    set_finalizer_for_instance
    set_finalizer_for_memory
    set_finalizer_for_memorytype

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -70,6 +70,8 @@ final _wasmFnImportTrampolineNative = Pointer.fromFunction<
   Pointer<WasmerValVec>,
 )>(_wasmFnImportTrampoline);
 final _wasmFnImportToFn = <int, Function>{};
+
+// ignore: unused_element
 final _wasmFnImportFinalizerNative =
     Pointer.fromFunction<Void Function(Pointer<_WasmFnImport>)>(
   _wasmFnImportFinalizer,

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -164,7 +164,7 @@ class WasmInstanceBuilder {
       funcType,
       _wasmFnImportTrampolineNative,
       wasmFnImport,
-      _wasmFnImportFinalizerNative,
+      nullptr, // TODO(#47): Re-enable _wasmFnImportFinalizerNative.
     );
     _imports.ref.data[index] = runtime.functionToExtern(fnImp);
   }
@@ -179,7 +179,7 @@ class WasmInstanceBuilder {
     }
 
     final globalType = imp.type as Pointer<WasmerGlobaltype>;
-    final global = runtime.newGlobal(globalType, val);
+    final global = runtime.newGlobal(_importOwner, globalType, val);
     _imports.ref.data[index] = runtime.globalToExtern(global);
     return WasmGlobal._('${imp.moduleName}::${imp.name}', global);
   }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -71,6 +71,7 @@ final _wasmFnImportTrampolineNative = Pointer.fromFunction<
 )>(_wasmFnImportTrampoline);
 final _wasmFnImportToFn = <int, Function>{};
 
+// This will be needed again once #47 is fixed.
 // ignore: unused_element
 final _wasmFnImportFinalizerNative =
     Pointer.fromFunction<Void Function(Pointer<_WasmFnImport>)>(

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -261,9 +261,6 @@ class WasmInstance {
         // WASM currently allows only one memory per module.
         final mem = runtime.externToMemory(e);
         _exportedMemory = mem;
-        if (_wasiEnv != nullptr) {
-          runtime.wasiEnvSetMemory(_wasiEnv, mem);
-        }
       } else if (kind == wasmerExternKindGlobal) {
         _globals[name] = WasmGlobal._(name, runtime.externToGlobal(e));
       }

--- a/lib/src/runtime.g.dart
+++ b/lib/src/runtime.g.dart
@@ -21,6 +21,7 @@ class WasmRuntime {
   late final WasmerDartInitializeApiDLFn _Dart_InitializeApiDL;
   late final WasmerSetFinalizerForEngineFn _set_finalizer_for_engine;
   late final WasmerSetFinalizerForFuncFn _set_finalizer_for_func;
+  late final WasmerSetFinalizerForGlobalFn _set_finalizer_for_global;
   late final WasmerSetFinalizerForInstanceFn _set_finalizer_for_instance;
   late final WasmerSetFinalizerForMemoryFn _set_finalizer_for_memory;
   late final WasmerSetFinalizerForMemorytypeFn _set_finalizer_for_memorytype;
@@ -127,6 +128,10 @@ class WasmRuntime {
     _set_finalizer_for_func = _lib.lookupFunction<
         NativeWasmerSetFinalizerForFuncFn, WasmerSetFinalizerForFuncFn>(
       'set_finalizer_for_func',
+    );
+    _set_finalizer_for_global = _lib.lookupFunction<
+        NativeWasmerSetFinalizerForGlobalFn, WasmerSetFinalizerForGlobalFn>(
+      'set_finalizer_for_global',
     );
     _set_finalizer_for_instance = _lib.lookupFunction<
         NativeWasmerSetFinalizerForInstanceFn, WasmerSetFinalizerForInstanceFn>(
@@ -746,11 +751,13 @@ class WasmRuntime {
   }
 
   Pointer<WasmerGlobal> newGlobal(
+    Object owner,
     Pointer<WasmerGlobaltype> globalType,
     dynamic val,
   ) {
     final wasmerVal = newValue(getGlobalKind(globalType), val);
     final global = _global_new(_store, globalType, wasmerVal);
+    _set_finalizer_for_global(owner, global);
     calloc.free(wasmerVal);
     return global;
   }

--- a/lib/src/runtime.g.dart
+++ b/lib/src/runtime.g.dart
@@ -34,7 +34,6 @@ class WasmRuntime {
   late final WasmerWasiEnvNewFn _wasi_env_new;
   late final WasmerWasiEnvReadStderrFn _wasi_env_read_stderr;
   late final WasmerWasiEnvReadStdoutFn _wasi_env_read_stdout;
-  late final WasmerWasiEnvSetMemoryFn _wasi_env_set_memory;
   late final WasmerWasiGetImportsFn _wasi_get_imports;
   late final WasmerByteVecDeleteFn _byte_vec_delete;
   late final WasmerByteVecNewFn _byte_vec_new;
@@ -181,10 +180,6 @@ class WasmRuntime {
     _wasi_env_read_stdout = _lib.lookupFunction<NativeWasmerWasiEnvReadStdoutFn,
         WasmerWasiEnvReadStdoutFn>(
       'wasi_env_read_stdout',
-    );
-    _wasi_env_set_memory = _lib.lookupFunction<NativeWasmerWasiEnvSetMemoryFn,
-        WasmerWasiEnvSetMemoryFn>(
-      'wasi_env_set_memory',
     );
     _wasi_get_imports = _lib
         .lookupFunction<NativeWasmerWasiGetImportsFn, WasmerWasiGetImportsFn>(
@@ -830,13 +825,6 @@ class WasmRuntime {
         nullptr,
         'Failed to create WASI environment.',
       );
-
-  void wasiEnvSetMemory(
-    Pointer<WasmerWasiEnv> env,
-    Pointer<WasmerMemory> memory,
-  ) {
-    _wasi_env_set_memory(env, memory);
-  }
 
   void getWasiImports(
     Pointer<WasmerModule> mod,

--- a/lib/src/wasmer_api.g.dart
+++ b/lib/src/wasmer_api.g.dart
@@ -217,12 +217,6 @@ typedef NativeWasmerWasiEnvReadStdoutFn = Int64 Function(
 typedef WasmerWasiEnvReadStdoutFn = int Function(
     Pointer<WasmerWasiEnv>, Pointer<Uint8>, int);
 
-// wasi_env_set_memory
-typedef NativeWasmerWasiEnvSetMemoryFn = Void Function(
-    Pointer<WasmerWasiEnv>, Pointer<WasmerMemory>);
-typedef WasmerWasiEnvSetMemoryFn = void Function(
-    Pointer<WasmerWasiEnv>, Pointer<WasmerMemory>);
-
 // wasi_get_imports
 typedef NativeWasmerWasiGetImportsFn = Uint8 Function(Pointer<WasmerStore>,
     Pointer<WasmerModule>, Pointer<WasmerWasiEnv>, Pointer<WasmerExternVec>);

--- a/lib/src/wasmer_api.g.dart
+++ b/lib/src/wasmer_api.g.dart
@@ -141,6 +141,12 @@ typedef NativeWasmerSetFinalizerForFuncFn = Void Function(
 typedef WasmerSetFinalizerForFuncFn = void Function(
     Object, Pointer<WasmerFunc>);
 
+// set_finalizer_for_global
+typedef NativeWasmerSetFinalizerForGlobalFn = Void Function(
+    Handle, Pointer<WasmerGlobal>);
+typedef WasmerSetFinalizerForGlobalFn = void Function(
+    Object, Pointer<WasmerGlobal>);
+
 // set_finalizer_for_instance
 typedef NativeWasmerSetFinalizerForInstanceFn = Void Function(
     Handle, Pointer<WasmerInstance>);

--- a/tool/generate_ffi_boilerplate.py
+++ b/tool/generate_ffi_boilerplate.py
@@ -345,7 +345,6 @@ wasi_env_t* wasi_env_new(wasi_config_t* config);
 bool wasi_get_imports(const wasm_store_t* store, const wasm_module_t* module, const wasi_env_t* wasi_env, wasm_extern_vec_t* imports);
 int wasmer_last_error_message(uint8_t* buffer, int length);
 int wasmer_last_error_length();
-void wasi_env_set_memory(wasi_env_t* env, const wasm_memory_t* memory);
 void wasi_config_capture_stdout(wasi_config_t* config);
 void wasi_config_capture_stderr(wasi_config_t* config);
 intptr_t wasi_env_read_stderr(wasi_env_t* env, uint8_t* buffer, uintptr_t buffer_len);

--- a/tool/generate_ffi_boilerplate.py
+++ b/tool/generate_ffi_boilerplate.py
@@ -359,6 +359,7 @@ void set_finalizer_for_trap(Dart_Handle, wasm_trap_t*);
 void set_finalizer_for_memorytype(Dart_Handle, wasm_memorytype_t*);
 void set_finalizer_for_memory(Dart_Handle, wasm_memory_t*);
 void set_finalizer_for_func(Dart_Handle, wasm_func_t*);
+void set_finalizer_for_global(Dart_Handle, wasm_global_t*);
 '''
 for f in rawFns.split('\n'):
     if len(f.strip()) > 0:

--- a/tool/runtime_template.dart.t
+++ b/tool/runtime_template.dart.t
@@ -352,13 +352,6 @@ class WasmRuntime {
         'Failed to create WASI environment.',
       );
 
-  void wasiEnvSetMemory(
-    Pointer<WasmerWasiEnv> env,
-    Pointer<WasmerMemory> memory,
-  ) {
-    _wasi_env_set_memory(env, memory);
-  }
-
   void getWasiImports(
     Pointer<WasmerModule> mod,
     Pointer<WasmerWasiEnv> env,

--- a/tool/runtime_template.dart.t
+++ b/tool/runtime_template.dart.t
@@ -272,11 +272,13 @@ class WasmRuntime {
   }
 
   Pointer<WasmerGlobal> newGlobal(
+    Object owner,
     Pointer<WasmerGlobaltype> globalType,
     dynamic val,
   ) {
     final wasmerVal = newValue(getGlobalKind(globalType), val);
     final global = _global_new(_store, globalType, wasmerVal);
+    _set_finalizer_for_global(owner, global);
     calloc.free(wasmerVal);
     return global;
   }


### PR DESCRIPTION
Fixes #20 

It looks like the only significant change is that `wasi_env_set_memory` is no longer necessary and was removed. [Context](https://github.com/wasmerio/wasmer/blob/4fb94aff7ebee752e20cc9d573032a66723668c6/lib/c-api/wasmer_wasm.h#L224)