### PR TITLE
Migrate WasmModule construction to top-level factory functions.

### DIFF
--- a/flutter_wasm/example/lib/main.dart
+++ b/flutter_wasm/example/lib/main.dart
@@ -14,7 +14,7 @@ final _data = Uint8List.fromList([
   0x7e, 0x0b,
 ]);
 
-final _inst = WasmModule(_data).builder().build();
+final _inst = wasmModuleCompileSync(_data).builder().build();
 final _wasmSquare = _inst.lookupFunction('square');
 
 void main() {

--- a/flutter_wasm/test/flutter_wasm_test.dart
+++ b/flutter_wasm/test/flutter_wasm_test.dart
@@ -22,7 +22,7 @@ void main() {
       0x7e, 0x0b,
     ]);
 
-    var inst = WasmModule(data).builder().build();
+    var inst = wasmModuleCompileSync(data).builder().build();
     var fn = inst.lookupFunction('square');
     var n = fn(1234) as int;
 

--- a/wasm/CHANGELOG.md
+++ b/wasm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0-dev
+
+- Provide a new way for creating a WasmModule via 
+  `wasmModuleCompileAsync` and `wasmModuleCompileSync`
+
 ## 0.2.0-dev
 
 - Update to Wasmer 2.1.0

--- a/wasm/example/brotli_api.dart
+++ b/wasm/example/brotli_api.dart
@@ -20,7 +20,7 @@ class Brotli {
 
   /// Construct a Brotli compressor.
   Brotli(Uint8List brotliWasmModuleData) {
-    final module = WasmModule(brotliWasmModuleData);
+    final module = wasmModuleCompileSync(brotliWasmModuleData);
     final builder = module.builder()..enableWasi();
     _instance = builder.build();
     _memory = _instance.memory;

--- a/wasm/lib/src/module.dart
+++ b/wasm/lib/src/module.dart
@@ -11,18 +11,28 @@ import 'runtime.dart';
 import 'wasm_error.dart';
 import 'wasmer_api.dart';
 
+/// Creates a new wasm module asynchronously.
+Future<WasmModule> wasmModuleCompileAsync(
+  Uint8List data,
+) async {
+  return wasmModuleCompileSync(data);
+}
+
+/// Creates a new wasm module synchronously.
+WasmModule wasmModuleCompileSync(
+  Uint8List data,
+) {
+  return WasmModule._(data);
+}
+
 /// A compiled module that can be instantiated.
 class WasmModule {
   late final Pointer<WasmerModule> _module;
 
   /// Compile a module.
-  WasmModule(Uint8List data) {
+  WasmModule._(Uint8List data) {
     _module = runtime.compile(this, data);
   }
-
-  /// Asynchronously compile a module.
-  static Future<WasmModule> compileAsync(Uint8List data) async =>
-      Future<WasmModule>(() => WasmModule(data));
 
   /// Returns a [WasmInstanceBuilder] that is used to add all the imports that
   /// the module needs before instantiating it.

--- a/wasm/pubspec.yaml
+++ b/wasm/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wasm
-version: 0.2.0-dev
+version: 0.3.0-dev
 description: Utilities for loading and running WASM modules from Dart code
 repository: https://github.com/dart-lang/wasm/tree/main/wasm
 

--- a/wasm/test/async_test.dart
+++ b/wasm/test/async_test.dart
@@ -21,7 +21,7 @@ void main() {
       0x7e, 0x0b,
     ]);
 
-    final mod = await WasmModule.compileAsync(data);
+    final mod = await wasmModuleCompileAsync(data);
     final inst = await mod.builder().buildAsync();
     final fn = inst.lookupFunction('square');
     final n = fn(1234) as int;

--- a/wasm/test/basic_test.dart
+++ b/wasm/test/basic_test.dart
@@ -21,7 +21,7 @@ void main() {
       0x7e, 0x0b,
     ]);
 
-    var inst = WasmModule(data).builder().build();
+    var inst = wasmModuleCompileSync(data).builder().build();
     var fn = inst.lookupFunction('square');
     var n = fn(1234) as int;
 

--- a/wasm/test/corrupted_error_test.dart
+++ b/wasm/test/corrupted_error_test.dart
@@ -20,7 +20,7 @@ void main() {
     ]);
 
     expect(
-      () => WasmModule(data),
+      () => wasmModuleCompileSync(data),
       throwsWasmError(
         allOf(
           contains('Wasm module compilation failed.'),

--- a/wasm/test/fn_call_error_test.dart
+++ b/wasm/test/fn_call_error_test.dart
@@ -22,7 +22,7 @@ void main() {
       0x7e, 0x0b,
     ]);
 
-    var inst = WasmModule(data).builder().build();
+    var inst = wasmModuleCompileSync(data).builder().build();
     var fn = inst.lookupFunction('square');
 
     expect(() => fn(), throwsA(isArgumentError));

--- a/wasm/test/fn_import_exception_test.dart
+++ b/wasm/test/fn_import_exception_test.dart
@@ -26,7 +26,7 @@ void main() {
     ]);
 
     var thrownException = Exception('Hello exception!');
-    var inst = (WasmModule(data).builder()
+    var inst = (wasmModuleCompileSync(data).builder()
           ..addFunction('env', 'a', () {
             throw thrownException;
           })
@@ -38,7 +38,7 @@ void main() {
     var fn = inst.lookupFunction('fn');
     expect(() => fn(), throwsA(thrownException));
 
-    inst = (WasmModule(data).builder()
+    inst = (wasmModuleCompileSync(data).builder()
           ..addFunction('env', 'a', expectAsync0(() => null))
           ..addFunction('env', 'b', expectAsync0(() => null)))
         .build();

--- a/wasm/test/fn_import_test.dart
+++ b/wasm/test/fn_import_test.dart
@@ -26,7 +26,7 @@ void main() {
     var reportX = -1;
     var reportY = -1;
 
-    var inst = (WasmModule(data).builder()
+    var inst = (wasmModuleCompileSync(data).builder()
           ..addFunction('env', 'report', (int x, int y) {
             reportX = x;
             reportY = y;

--- a/wasm/test/globals_test.dart
+++ b/wasm/test/globals_test.dart
@@ -27,7 +27,7 @@ void main() {
       0x00, 0x00, 0x00,
     ]);
 
-    final builder = WasmModule(data).builder();
+    final builder = wasmModuleCompileSync(data).builder();
     final bar = builder.addGlobal('env', 'bar', 10);
     final inst = builder.build();
     final foo = inst.lookupGlobal('foo')!;

--- a/wasm/test/hello_wasi_test.dart
+++ b/wasm/test/hello_wasi_test.dart
@@ -13,7 +13,7 @@ void main() {
   test(
     'hello wasi',
     () async {
-      var builder = WasmModule(_data).builder()
+      var builder = wasmModuleCompileSync(_data).builder()
         ..enableWasi(captureStdout: true);
       var inst = builder.build();
 

--- a/wasm/test/hello_world_test.dart
+++ b/wasm/test/hello_world_test.dart
@@ -184,7 +184,7 @@ void main() {
       return n;
     }
 
-    var builder = WasmModule(data).builder()
+    var builder = wasmModuleCompileSync(data).builder()
       ..addFunction('wasi_unstable', 'fd_write',
           (int fd, int iovs, int iovsLen, int unused) {
         // iovs points to an array of length iovs_len. Each element is two I32s,

--- a/wasm/test/import_error_test.dart
+++ b/wasm/test/import_error_test.dart
@@ -27,7 +27,7 @@ void main() {
       0x80, 0x80, 0x80, 0x00, 0x1a, 0x0b,
     ]);
 
-    var mod = WasmModule(data);
+    var mod = wasmModuleCompileSync(data);
 
     // Valid instantiation.
     (mod.builder()

--- a/wasm/test/memory_error_test.dart
+++ b/wasm/test/memory_error_test.dart
@@ -16,7 +16,7 @@ void main() {
     var data = Uint8List.fromList([
       0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x81, 0x00, 0x00, //
     ]);
-    var module = WasmModule(data);
+    var module = wasmModuleCompileSync(data);
 
     expect(
       () => module.createMemory(1000000000),

--- a/wasm/test/memory_test.dart
+++ b/wasm/test/memory_test.dart
@@ -14,7 +14,7 @@ void main() {
     var data = Uint8List.fromList([
       0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x81, 0x00, 0x00, //
     ]);
-    var module = WasmModule(data);
+    var module = wasmModuleCompileSync(data);
 
     var mem = module.createMemory(100);
     expect(mem.lengthInPages, 100);

--- a/wasm/test/numerics_test.dart
+++ b/wasm/test/numerics_test.dart
@@ -30,7 +30,7 @@ void main() {
       0x01, 0x92, 0x0b,
     ]);
 
-    var inst = WasmModule(data).builder().build();
+    var inst = wasmModuleCompileSync(data).builder().build();
     var addI64 = inst.lookupFunction('addI64');
     var addI32 = inst.lookupFunction('addI32');
     var addF64 = inst.lookupFunction('addF64');

--- a/wasm/test/trap_test.dart
+++ b/wasm/test/trap_test.dart
@@ -25,7 +25,7 @@ void main() {
       0x6d, 0x6f, 0x72, 0x79,
     ]);
 
-    final inst = WasmModule(data).builder().build();
+    final inst = wasmModuleCompileSync(data).builder().build();
     final foo = inst.lookupFunction('foo');
     // ignore: unnecessary_lambdas
     expect(() => foo(), throwsWasmException('unreachable'));

--- a/wasm/test/void_test.dart
+++ b/wasm/test/void_test.dart
@@ -26,7 +26,7 @@ void main() {
       0x80, 0x08, 0x0b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     ]);
 
-    var inst = WasmModule(data).builder().build();
+    var inst = wasmModuleCompileSync(data).builder().build();
     var setFn = inst.lookupFunction('set');
     var getFn = inst.lookupFunction('get');
     expect(setFn(123, 456), isNull);

--- a/wasm/test/wasi_error_test.dart
+++ b/wasm/test/wasi_error_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     // Failed to fill WASI imports (the empty module was not built with WASI).
     expect(
-      () => WasmModule(emptyModuleData).builder().enableWasi(),
+      () => wasmModuleCompileSync(emptyModuleData).builder().enableWasi(),
       throwsWasmError(startsWith('Failed to fill WASI imports.')),
     );
 
@@ -185,7 +185,7 @@ void main() {
 
     // Trying to import WASI twice.
     expect(
-      () => WasmModule(helloWorldData).builder()
+      () => wasmModuleCompileSync(helloWorldData).builder()
         ..enableWasi()
         ..enableWasi(),
       throwsWasmError(startsWith('WASI is already enabled')),
@@ -193,13 +193,13 @@ void main() {
 
     // Missing imports due to not enabling WASI.
     expect(
-      () => WasmModule(helloWorldData).builder().build(),
+      () => wasmModuleCompileSync(helloWorldData).builder().build(),
       throwsWasmError(startsWith('Missing import: ')),
     );
 
     // Trying to get stdout/stderr without WASI enabled (WASI function import has
     // been manually filled).
-    var inst = (WasmModule(helloWorldData).builder()
+    var inst = (wasmModuleCompileSync(helloWorldData).builder()
           ..addFunction(
             'wasi_unstable',
             'fd_write',


### PR DESCRIPTION
See #92 step 2.

The following are some TODOs as a note to myself:

- the circular dependency between runtime.compile and WasmModule should be broken by having the owner be a function that receives the pointer and returns an owner and a generic return type.
- the async version for constructing a WasmModule is not doing anything that the sync version isn't doing and could be removed. It seems to act as a reminder for providing an async construction scheme in the future?