### PR TITLE
Migrate finalizers

### DIFF
--- a/wasm/CHANGELOG.md
+++ b/wasm/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add options to `setup.dart` for configuring the build.
 - Add `WasmModule.compileAsync` and `WasmInstanceBuilder.buildAsync`, so that
   the web API can be supported in the future.
+- Migrate dart finalizers from native to dart.
 
 ## 0.1.0+1
 

--- a/wasm/lib/src/runtime.g.dart
+++ b/wasm/lib/src/runtime.g.dart
@@ -505,10 +505,10 @@ class WasmRuntime {
     }
     _engine = _engine_new();
     _checkNotEqual(_engine, nullptr, 'Failed to initialize Wasm engine.');
-    _set_finalizer_for_engine(this, _engine);
+    Finalizer(_engine_delete).attach(this, _engine);
     _store = _store_new(_engine);
     _checkNotEqual(_store, nullptr, 'Failed to create Wasm store.');
-    _set_finalizer_for_store(this, _store);
+    Finalizer(_store_delete).attach(this, _store);
   }
 
   Pointer<WasmerModule> compile(Object owner, Uint8List data) {
@@ -526,7 +526,7 @@ class WasmRuntime {
     calloc.free(dataVec);
 
     _checkNotEqual(modulePtr, nullptr, 'Wasm module compilation failed.');
-    _set_finalizer_for_module(owner, modulePtr);
+    Finalizer(_module_delete).attach(owner, modulePtr);
     return modulePtr;
   }
 
@@ -616,7 +616,7 @@ class WasmRuntime {
     maybeThrowTrap(trap.value, 'module initialization function');
     calloc.free(trap);
     _checkNotEqual(inst, nullptr, 'Wasm module instantiation failed.');
-    _set_finalizer_for_instance(owner, inst);
+    Finalizer(_instance_delete).attach(owner, inst);
     return inst;
   }
 
@@ -685,13 +685,13 @@ class WasmRuntime {
     var memType = _memorytype_new(limPtr);
     calloc.free(limPtr);
     _checkNotEqual(memType, nullptr, 'Failed to create memory type.');
-    _set_finalizer_for_memorytype(owner, memType);
+    Finalizer(_memorytype_delete).attach(owner, memType);
     var memory = _checkNotEqual(
       _memory_new(_store, memType),
       nullptr,
       'Failed to create memory.',
     );
-    _set_finalizer_for_memory(owner, memory);
+    Finalizer(_memory_delete).attach(owner, memory);
     return memory;
   }
 
@@ -723,7 +723,7 @@ class WasmRuntime {
       finalizer.cast(),
     );
     _checkNotEqual(f, nullptr, 'Failed to create function.');
-    _set_finalizer_for_func(owner, f);
+    Finalizer(_func_delete).attach(owner, f);
     return f;
   }
 
@@ -744,7 +744,7 @@ class WasmRuntime {
   ) {
     final wasmerVal = newValue(getGlobalKind(globalType), val);
     final global = _global_new(_store, globalType, wasmerVal);
-    _set_finalizer_for_global(owner, global);
+    Finalizer(_global_delete).attach(owner, global);
     calloc.free(wasmerVal);
     return global;
   }
@@ -799,7 +799,7 @@ class WasmRuntime {
     calloc.free(bytes);
     _checkNotEqual(trap, nullptr, 'Failed to create trap.');
     var entry = _WasmTrapsEntry(exception);
-    _set_finalizer_for_trap(entry, trap);
+    Finalizer(_trap_delete).attach(entry, trap);
     _traps[msg] = entry;
     return trap;
   }


### PR DESCRIPTION
Context #95
After this change, the build step for wasmer should reduce to building the wasmer library only. Creating bindings for ios, android and so on should therefore become significantly simpler.

@liamappelbe what do you think? I haven't used this API yet personally, but it seems like it was built for this purpose and is probably a wrapper around the same API that you were using natively.