### PR TITLE
example: rename example file to follow convention

### DIFF
--- a/wasm/example/README.md
+++ b/wasm/example/README.md
@@ -5,7 +5,7 @@ This example demonstrates how to use package:wasm to run a wasm build of the
 
 ### Running the example
 
-`dart brotli.dart lipsum.txt`
+`dart example.dart lipsum.txt`
 
 This will compress lipsum.txt, report the compression ratio, then decompress it
 and verify that the result matches the input.

--- a/wasm/example/example.dart
+++ b/wasm/example/example.dart
@@ -4,7 +4,7 @@
 
 // Example of using package:wasm to run a wasm build of the Brotli compression
 // library. Usage:
-// dart brotli.dart input.txt
+// dart example.dart input.txt
 
 import 'dart:io';
 


### PR DESCRIPTION
So it shows up on pub.dev

See https://dart.dev/tools/pub/package-layout#examples
